### PR TITLE
Fix lodash-es import in frontend build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "pinia": "^2.1.6",
     "axios": "^1.5.0",
     "@vueuse/core": "^10.4.1",
-    "gsap": "^3.12.2"
+    "gsap": "^3.12.2",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.3.4",


### PR DESCRIPTION
Add `lodash-es` to frontend dependencies to resolve build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-74a1e8eb-c9dd-45cf-8f8e-5bc59ef56c0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74a1e8eb-c9dd-45cf-8f8e-5bc59ef56c0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

