### PR TITLE
Retry database connection with ssl error

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -2,7 +2,7 @@ const { Pool } = require('pg');
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  ssl: process.env.NODE_ENV === 'production' && process.env.DATABASE_SSL !== 'false' ? { rejectUnauthorized: false } : false,
   max: 20,     // Maximum number of clients in the pool
   idleTimeoutMillis: 30000, // Close idle clients after 30 seconds
   connectionTimeoutMillis: 2000, // Return an error after 2 seconds if connection could not be established

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,7 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: postgresql://neovolt:${DB_PASSWORD}@postgres:5432/neovolt
+      DATABASE_SSL: false
       JWT_SECRET: ${JWT_SECRET}
       PAYPAL_CLIENT_ID: ${PAYPAL_CLIENT_ID}
       PAYPAL_CLIENT_SECRET: ${PAYPAL_CLIENT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: postgresql://postgres:neovolt123@postgres:5432/neovolt
+      DATABASE_SSL: false
       JWT_SECRET: your-super-secret-jwt-key-change-in-production
       PAYPAL_CLIENT_ID: your-paypal-client-id
       PAYPAL_CLIENT_SECRET: your-paypal-client-secret


### PR DESCRIPTION
Disable PostgreSQL SSL connection for Docker environments to resolve "The server does not support SSL connections" error.

The application's `database.js` was configured to enable SSL when `NODE_ENV` is `production`, but the PostgreSQL container did not support SSL. This change introduces a `DATABASE_SSL` environment variable to explicitly disable SSL in Docker Compose files, preventing SSL connection attempts within the internal Docker network.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce1e72c7-fc17-4d5f-9a76-5a429df218f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce1e72c7-fc17-4d5f-9a76-5a429df218f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

